### PR TITLE
fix typo that broke return type on edge case where 'or' in both names

### DIFF
--- a/NameComparator/src/modify.py
+++ b/NameComparator/src/modify.py
@@ -52,7 +52,7 @@ def _removeOrInNames(nameA:str, nameB:str) -> tuple[str, str]:
     
     # if or in both
     elif (" or " in nameA) and (" or " in nameB):
-        return nameA, 
+        return nameA, nameB
 
     # if or in nameA and not nameB
     elif " or " in nameA:


### PR DESCRIPTION
literally just an accidental deletion of half the return object that never got noticed because it is for an edge case where the word 'or' is in both names. Likely hit a case where Or was a last name when running PyFS and did not get noticed til now